### PR TITLE
Horizon reliability improvements

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -82,6 +82,7 @@ lazy val root = (project in file("."))
       "ch.qos.logback" % "logback-classic" % "1.2.3",
       "org.typelevel" %% "cats-core" % "1.6.1",
       "tech.sparse" %%  "toml-scala" % "0.2.0",
+      "com.softwaremill.retry" %% "retry" % "0.3.2",
       "org.specs2" %% "specs2-core" % "4.5.1" % "test,it",
       "org.specs2" %% "specs2-mock" % "4.5.1" % "test",
       "org.specs2" %% "specs2-scalacheck" % "4.5.1" % "test"

--- a/src/it/scala/stellar/sdk/LocalNetworkIntegrationSpec.scala
+++ b/src/it/scala/stellar/sdk/LocalNetworkIntegrationSpec.scala
@@ -486,5 +486,12 @@ class LocalNetworkIntegrationSpec(implicit ee: ExecutionEnv) extends Specificati
       results.map(_.size) must beEqualTo(1).awaitFor(1 minute)
     }
   }
+
+  "page deserialisation" should {
+    "return an empty page when the underlying resource does not exist" >> {
+      network.horizon.getStream("/does_not_exist", TradeDeserializer, Now, Asc) must beEmpty[Stream[Trade]]
+          .awaitFor(10.seconds)
+    }
+  }
 }
 

--- a/src/main/scala/stellar/sdk/KeyPair.scala
+++ b/src/main/scala/stellar/sdk/KeyPair.scala
@@ -226,6 +226,8 @@ object Signature {
   } yield Signature(data, hint)
 }
 
+case class FailedResponse(cause: String) extends RuntimeException(cause)
+
 case class InvalidAccountId(id: String, cause: Throwable) extends RuntimeException(id, cause)
 
 case class InvalidSecretSeed(cause: Throwable) extends RuntimeException(cause)

--- a/src/main/scala/stellar/sdk/KeyPair.scala
+++ b/src/main/scala/stellar/sdk/KeyPair.scala
@@ -226,8 +226,6 @@ object Signature {
   } yield Signature(data, hint)
 }
 
-case class FailedResponse(cause: String) extends RuntimeException(cause)
-
 case class InvalidAccountId(id: String, cause: Throwable) extends RuntimeException(id, cause)
 
 case class InvalidSecretSeed(cause: Throwable) extends RuntimeException(cause)

--- a/src/main/scala/stellar/sdk/PublicNetwork.scala
+++ b/src/main/scala/stellar/sdk/PublicNetwork.scala
@@ -9,7 +9,7 @@ import stellar.sdk.inet.Horizon
   */
 case object PublicNetwork extends Network {
   override val passphrase = "Public Global Stellar Network ; September 2015"
-  val horizon = new Horizon(URI.create("https://horizon.stellar.org"))
+  val horizon = Horizon(URI.create("https://horizon.stellar.org"))
 }
 
 

--- a/src/main/scala/stellar/sdk/StandaloneNetwork.scala
+++ b/src/main/scala/stellar/sdk/StandaloneNetwork.scala
@@ -11,7 +11,7 @@ import stellar.sdk.inet.{Horizon, HorizonAccess}
   */
 case class StandaloneNetwork(uri: URI) extends Network with FriendBot {
   override val passphrase: String = "Standalone Network ; February 2017"
-  override val horizon: HorizonAccess = new Horizon(uri)
+  override val horizon: HorizonAccess = Horizon(uri)
 }
 
 

--- a/src/main/scala/stellar/sdk/TestNetwork.scala
+++ b/src/main/scala/stellar/sdk/TestNetwork.scala
@@ -9,7 +9,7 @@ import stellar.sdk.inet.Horizon
   */
 case object TestNetwork extends Network with FriendBot {
   override val passphrase = "Test SDF Network ; September 2015"
-  val horizon = new Horizon(URI.create("https://horizon-testnet.stellar.org"))
+  val horizon = Horizon(URI.create("https://horizon-testnet.stellar.org"))
 }
 
 

--- a/src/main/scala/stellar/sdk/inet/HorizonAccess.scala
+++ b/src/main/scala/stellar/sdk/inet/HorizonAccess.scala
@@ -115,7 +115,7 @@ class Horizon(call: HttpRequest => Future[HttpResponse])
     // 3xx - Redirect
     else if (status.isRedirection()) {
       val request_ = request.copy(uri = response.header[Location].get.uri)
-      Http().singleRequest(request).flatMap(parseOrRedirectOrError(request_, _))
+      Http().singleRequest(request_).flatMap(parseOrRedirectOrError(request_, _))
     }
 
     // 200 or 4xx

--- a/src/main/scala/stellar/sdk/inet/HorizonAccess.scala
+++ b/src/main/scala/stellar/sdk/inet/HorizonAccess.scala
@@ -292,7 +292,7 @@ class MultiHostCaller(uris: NonEmptyList[Uri], maxNumberOfRetry: Int, backoff: F
     request.copy(uri = getFullUri(base, request.uri))
 
   private def getFullUri(base: Uri, path: Uri): Uri =
-    Uri().withPath(base.path ++ path.path)
+    base.withPath(base.path ++ path.path)
 
   private def handleResponse(request: HttpRequest, response: HttpResponse): Future[Try[HttpResponse]] = {
     response.status match {

--- a/src/main/scala/stellar/sdk/inet/HorizonAccess.scala
+++ b/src/main/scala/stellar/sdk/inet/HorizonAccess.scala
@@ -139,10 +139,10 @@ class Horizon(call: HttpRequest => Future[HttpResponse])
       "limit" -> "100"
     ))
 
-    val requestUri = Uri(s"$path").withQuery(query)
+    val requestUri = Uri(path).withQuery(query)
 
     def next(p: Page[T]): Future[Option[Page[T]]] =
-      (getPage(Uri(p.nextLink).withPort(requestUri.effectivePort)): Future[Page[T]]).map(Some(_))
+      (getPage(Uri(p.nextLink)): Future[Page[T]]).map(Some(_))
 
     def stream(ts: Seq[T], maybeNextPage: Future[Option[Page[T]]]): Stream[T] = {
       ts match {

--- a/src/main/scala/stellar/sdk/inet/HorizonAccess.scala
+++ b/src/main/scala/stellar/sdk/inet/HorizonAccess.scala
@@ -20,7 +20,7 @@ import com.typesafe.scalalogging.LazyLogging
 import de.heikoseeberger.akkahttpjson4s.Json4sSupport
 import org.json4s.native.{JsonMethods, Serialization}
 import org.json4s.{CustomSerializer, DefaultFormats, Formats, JObject, NoTypeHints}
-import stellar.sdk.{BuildInfo, DefaultActorSystem, FailedResponse}
+import stellar.sdk.{BuildInfo, DefaultActorSystem}
 import stellar.sdk.model._
 import stellar.sdk.model.op.TransactedOperationDeserializer
 import stellar.sdk.model.response._

--- a/src/main/scala/stellar/sdk/inet/HorizonAccess.scala
+++ b/src/main/scala/stellar/sdk/inet/HorizonAccess.scala
@@ -26,7 +26,7 @@ import stellar.sdk.model.op.TransactedOperationDeserializer
 import stellar.sdk.model.response._
 import stellar.sdk.model.result.TransactionHistoryDeserializer
 
-import scala.concurrent.duration.FiniteDuration
+import scala.concurrent.duration._
 import scala.concurrent.{Await, ExecutionContext, Future}
 import scala.reflect.ClassTag
 import scala.util.{Failure, Success, Try}
@@ -174,7 +174,7 @@ class Horizon(call: HttpRequest => Future[HttpResponse])
         () => call(request)
 
     logger.debug(s"Getting $uri")
-    val request = HttpRequest(GET, uri).addHeader(clientNameHeader).addHeader(clientVersionHeader)
+
     getResponse().flatMap {
       case response if response.status == StatusCodes.NotFound => Future(Page(Seq.empty[T], uri.toString()))
       case response                                            => Unmarshal(response).to[RawPage].map(_.parse[T])

--- a/src/main/scala/stellar/sdk/inet/HorizonServerError.scala
+++ b/src/main/scala/stellar/sdk/inet/HorizonServerError.scala
@@ -16,3 +16,5 @@ case class HorizonEntityNotFound(uri: Uri, body: JObject)(implicit val formats: 
 case class HorizonRateLimitExceeded(uri: Uri, retryAfter: Duration)(implicit val formats: Formats) extends Exception(
   s"Horizon request rate limit was exceeded. Try again in $retryAfter"
 )
+
+case class FailedResponse(cause: String) extends Exception(cause)

--- a/src/test/scala/stellar/sdk/inet/HorizonSpec.scala
+++ b/src/test/scala/stellar/sdk/inet/HorizonSpec.scala
@@ -1,34 +1,29 @@
 package stellar.sdk.inet
 
-import java.net.URI
-
+import akka.actor.ActorSystem
+import akka.http.scaladsl.Http
 import akka.http.scaladsl.model.HttpCharsets.`UTF-8`
-import akka.http.scaladsl.model.RequestEntity
 import akka.http.scaladsl.model._
 import akka.http.scaladsl.model.headers.{Location, RawHeader}
+import org.json4s.JsonDSL._
 import org.json4s.native.JsonMethods._
+import org.specs2.concurrent.ExecutionEnv
 import org.specs2.mock.Mockito
 import org.specs2.mutable.Specification
-import org.json4s.JsonDSL._
-import org.specs2.concurrent.ExecutionEnv
 
 import scala.collection.immutable
+import scala.concurrent.Future
 import scala.concurrent.duration._
-import scala.concurrent.Await
 
 class HorizonSpec(implicit ec: ExecutionEnv) extends Specification with Mockito {
 
-  "creating a server from string" should {
-    "fail when uri is invalid" >> {
-      HorizonAccess("fruit:\\foo") must beFailedTry[HorizonAccess]
-    }
-    "succeed when uri is compliant" >> {
-      HorizonAccess("https://horizon.stellar.org") must beSuccessfulTry[HorizonAccess]
-    }
-  }
+  implicit val system = ActorSystem()
 
   val uri = Uri("https://test/")
   val request = new HttpRequest(HttpMethods.GET, uri, Nil, HttpEntity(""), HttpProtocols.`HTTP/2.0`)
+
+  def call(uri: Uri): HttpRequest => Future[HttpResponse] =
+    request => Http().singleRequest(request.copy(uri = request.uri.withPath(uri.path ++ request.uri.path)))
 
   "parsing a not-found response" should {
     "fail with a not found entity" >> {
@@ -38,7 +33,7 @@ class HorizonSpec(implicit ec: ExecutionEnv) extends Specification with Mockito 
         compact(render(responseBody))
       )
       val response = new HttpResponse(StatusCodes.NotFound, Nil, responseEntity, HttpProtocols.`HTTP/2.0`)
-      new Horizon(URI.create("https://test/")).parseOrRedirectOrError[String](request, response) must beFailedTry[String].like {
+      new Horizon(call(uri)).parseOrRedirectOrError[String](request, response) must beFailedTry[String].like {
         case HorizonEntityNotFound(requestUri, doc) =>
           requestUri mustEqual uri
           doc mustEqual responseBody
@@ -55,7 +50,7 @@ class HorizonSpec(implicit ec: ExecutionEnv) extends Specification with Mockito 
       )
       val headers = immutable.Seq(RawHeader("X-Ratelimit-Reset", "7"))
       val response = new HttpResponse(StatusCodes.TooManyRequests, headers, responseEntity, HttpProtocols.`HTTP/2.0`)
-      new Horizon(URI.create("https://test/")).parseOrRedirectOrError[String](request, response) must beFailedTry[String].like {
+      new Horizon(call(uri)).parseOrRedirectOrError[String](request, response) must beFailedTry[String].like {
         case HorizonRateLimitExceeded(requestUri, retryAfter) =>
           requestUri mustEqual uri
           retryAfter mustEqual 7.seconds
@@ -71,7 +66,7 @@ class HorizonSpec(implicit ec: ExecutionEnv) extends Specification with Mockito 
         compact(render(responseBody))
       )
       val response = new HttpResponse(StatusCodes.InternalServerError, Nil, responseEntity, HttpProtocols.`HTTP/2.0`)
-      new Horizon(URI.create("https://test/")).parseOrRedirectOrError[String](request, response) must beFailedTry[String].like {
+      new Horizon(call(uri)).parseOrRedirectOrError[String](request, response) must beFailedTry[String].like {
         case HorizonServerError(requestUri, doc) =>
           requestUri mustEqual uri
           doc mustEqual responseBody


### PR DESCRIPTION
Add retry logic for failed futures.
Add multi host round robin requests for recoveries on failed responses.