### PR TITLE
jem/20201129 sponsored reserves json tests

### DIFF
--- a/src/main/scala/stellar/sdk/model/op/Operation.scala
+++ b/src/main/scala/stellar/sdk/model/op/Operation.scala
@@ -210,9 +210,11 @@ object OperationDeserializer extends ResponseParser[Operation]({ o: JObject =>
       )
     case "begin_sponsoring_future_reserves" =>
       BeginSponsoringFutureReservesOperation(
-        sponsored = AccountId(KeyPair.fromAccountId((o \ "sponsored_id").extract[String]).publicKey),
+        sponsored = accountId("sponsored_id"),
         sourceAccount
       )
+    case "end_sponsoring_future_reserves" =>
+      EndSponsoringFutureReservesOperation(sourceAccount)
     case t =>
       throw new RuntimeException(s"Unrecognised operation type '$t'")
   }

--- a/src/main/scala/stellar/sdk/model/op/Operation.scala
+++ b/src/main/scala/stellar/sdk/model/op/Operation.scala
@@ -208,6 +208,11 @@ object OperationDeserializer extends ResponseParser[Operation]({ o: JObject =>
         id = ClaimableBalanceId.decode.run(ByteString.decodeHex((o \ "balance_id").extract[String]).toByteArray).value._2,
         sourceAccount
       )
+    case "begin_sponsoring_future_reserves" =>
+      BeginSponsoringFutureReservesOperation(
+        sponsored = AccountId(KeyPair.fromAccountId((o \ "sponsored_id").extract[String]).publicKey),
+        sourceAccount
+      )
     case t =>
       throw new RuntimeException(s"Unrecognised operation type '$t'")
   }

--- a/src/test/scala/stellar/sdk/ArbitraryInput.scala
+++ b/src/test/scala/stellar/sdk/ArbitraryInput.scala
@@ -444,7 +444,7 @@ trait ArbitraryInput extends ScalaCheck {
   } yield ClaimClaimableBalanceOperation(id, sourceAccount)
 
   def genBeginSponsoringFutureReservesOperation: Gen[BeginSponsoringFutureReservesOperation] = for {
-    sponsored <- genAccountId
+    sponsored <- genPublicKey.map(_.publicKey).map(AccountId(_))
     sourceAccount <- Gen.option(genPublicKey)
   } yield BeginSponsoringFutureReservesOperation(sponsored, sourceAccount)
 

--- a/src/test/scala/stellar/sdk/model/op/BeginSponsoringFutureReservesOperationSpec.scala
+++ b/src/test/scala/stellar/sdk/model/op/BeginSponsoringFutureReservesOperationSpec.scala
@@ -1,14 +1,20 @@
 package stellar.sdk.model.op
 
+import org.json4s.{Formats, NoTypeHints}
+import org.json4s.native.JsonMethods.parse
+import org.json4s.native.Serialization
 import org.scalacheck.Arbitrary
 import org.specs2.mutable.Specification
 import stellar.sdk.ArbitraryInput
 import stellar.sdk.util.ByteArrays
 
-class BeginSponsoringFutureReservesOperationSpec extends Specification with ArbitraryInput {
+class BeginSponsoringFutureReservesOperationSpec extends Specification with ArbitraryInput with JsonSnippets {
 
   implicit val arbOp: Arbitrary[BeginSponsoringFutureReservesOperation] =
     Arbitrary(genBeginSponsoringFutureReservesOperation)
+  implicit val arbTx: Arbitrary[Transacted[BeginSponsoringFutureReservesOperation]] =
+    Arbitrary(genTransacted(genBeginSponsoringFutureReservesOperation))
+  implicit val formats: Formats = Serialization.formats(NoTypeHints) + TransactedOperationDeserializer
 
   "begin sponsoring future reserves operation" should {
     "serde via xdr bytes" >> prop { actual: BeginSponsoringFutureReservesOperation =>
@@ -20,6 +26,22 @@ class BeginSponsoringFutureReservesOperationSpec extends Specification with Arbi
     "serde via xdr string" >> prop { actual: BeginSponsoringFutureReservesOperation =>
       Operation.decodeXDR(ByteArrays.base64(actual.encode)) mustEqual actual
     }
+
+    "parse from json" >> prop { op: Transacted[BeginSponsoringFutureReservesOperation] =>
+      val doc =
+        s"""{
+           |  "id": "${op.id}",
+           |  "source_account": "${op.operation.sourceAccount.get.accountId}",
+           |  "type": "begin_sponsoring_future_reserves",
+           |  "type_i": 16,
+           |  "created_at": "${formatter.format(op.createdAt)}",
+           |  "transaction_hash": "${op.txnHash}",
+           |  "sponsored_id": "${op.operation.sponsored.publicKey.accountId}"
+           |}
+         """.stripMargin
+
+      parse(doc).extract[Transacted[BeginSponsoringFutureReservesOperation]] mustEqual op
+    }.setGen(genTransacted(genBeginSponsoringFutureReservesOperation.suchThat(_.sourceAccount.nonEmpty)))
   }
 
 }

--- a/src/test/scala/stellar/sdk/model/op/EndSponsoringReservesOperationSpec.scala
+++ b/src/test/scala/stellar/sdk/model/op/EndSponsoringReservesOperationSpec.scala
@@ -1,0 +1,48 @@
+package stellar.sdk.model.op
+
+import org.json4s.{Formats, NoTypeHints}
+import org.json4s.native.JsonMethods.parse
+import org.json4s.native.Serialization
+import org.scalacheck.Arbitrary
+import org.specs2.mutable.Specification
+import stellar.sdk.ArbitraryInput
+import stellar.sdk.util.ByteArrays
+
+class EndSponsoringReservesOperationSpec extends Specification with ArbitraryInput with JsonSnippets {
+
+  implicit val arbOp: Arbitrary[EndSponsoringFutureReservesOperation] =
+    Arbitrary(genEndSponsoringFutureReservesOperation)
+  implicit val arbTx: Arbitrary[Transacted[EndSponsoringFutureReservesOperation]] =
+    Arbitrary(genTransacted(genEndSponsoringFutureReservesOperation))
+  implicit val formats: Formats = Serialization.formats(NoTypeHints) + TransactedOperationDeserializer
+
+  "End sponsoring future reserves operation" should {
+    "serde via xdr bytes" >> prop { actual: EndSponsoringFutureReservesOperation =>
+      val (remaining, decoded) = Operation.decode.run(actual.encode).value
+      decoded mustEqual actual
+      remaining must beEmpty
+    }
+
+    "serde via xdr string" >> prop { actual: EndSponsoringFutureReservesOperation =>
+      Operation.decodeXDR(ByteArrays.base64(actual.encode)) mustEqual actual
+    }
+
+    "parse from json" >> prop { op: Transacted[EndSponsoringFutureReservesOperation] =>
+      val doc =
+        s"""{
+           |  "id": "${op.id}",
+           |  "source_account": "${op.operation.sourceAccount.get.accountId}",
+           |  "type": "end_sponsoring_future_reserves",
+           |  "type_i": 17,
+           |  "created_at": "${formatter.format(op.createdAt)}",
+           |  "transaction_hash": "${op.txnHash}",
+           |  "sponsored_id": "IGNORED"
+           |}""".stripMargin
+
+      parse(doc).extract[Transacted[EndSponsoringFutureReservesOperation]] mustEqual op
+    }.setGen(genTransacted(genEndSponsoringFutureReservesOperation.suchThat(_.sourceAccount.nonEmpty)))
+  }
+
+
+
+}


### PR DESCRIPTION
- BeginSponsoringFutureReservesOperation JSON test
- EndSponsoringFutureReservesOperation JSON test
